### PR TITLE
fix: flux-core, add uuid when czmq does not provide it

### DIFF
--- a/packages/flux-core/package.py
+++ b/packages/flux-core/package.py
@@ -135,7 +135,7 @@ class FluxCore(AutotoolsPackage):
     depends_on("libarchive+iconv", when="@0.38.0:")
     depends_on("ncurses@6.2:", when="@0.32.0:")
     depends_on("libzmq@4.0.4:")
-    depends_on("czmq@3.0.1:")
+    depends_on("czmq@3.0.1:", when="@:0.54.0")
     depends_on("hwloc@1.11.1:1", when="@:0.17.0")
     depends_on("hwloc@1.11.1:", when="@0.17.0:")
     depends_on("hwloc +cuda", when="+cuda")
@@ -153,14 +153,16 @@ class FluxCore(AutotoolsPackage):
     depends_on("py-cffi@1.1:", type=("build", "run"))
     depends_on("py-six@1.9:", when="@:0.24", type=("build", "run"))
     depends_on("py-pyyaml@3.10:", type=("build", "run"))
-    depends_on("py-jsonschema@2.3:", type=("build", "run"))
+    depends_on("py-jsonschema@2.3:", type=("build", "run"), when="@:0.58.0")
     depends_on("py-ply", type=("build", "run"), when="@0.46.1:")
     depends_on("jansson")
     depends_on("jansson@2.10:", when="@0.21.0:")
     depends_on("pkgconfig")
     depends_on("lz4")
     depends_on("sqlite")
-
+    
+    # Before this version, czmq brings it in 
+    depends_on("uuid", when="@0.55.0:")
     depends_on("asciidoc", type="build", when="+docs")
     depends_on("py-docutils", type="build", when="@0.32.0: +docs")
 


### PR DESCRIPTION
problem: removing czmq for later versions means we are missing uuid
solution: install uuid for that same range