### PR TITLE
test: pin flux-security libsodium to 1.0.18

### DIFF
--- a/packages/flux-security/package.py
+++ b/packages/flux-security/package.py
@@ -33,7 +33,7 @@ class FluxSecurity(AutotoolsPackage):
     depends_on("libtool", type="build", when="@master")
 
     depends_on("pkgconfig")
-    depends_on("libsodium@1.0.14:")
+    depends_on("libsodium@1.0.14:1.0.18")
     depends_on("jansson")
     depends_on("libuuid")
     depends_on("munge")


### PR DESCRIPTION
Problem: the checksum fails for 1.0.19
Solution: try pinning to 1.0.18