### PR TITLE
version: libuuid -> uuid

### DIFF
--- a/packages/flux-security/package.py
+++ b/packages/flux-security/package.py
@@ -35,7 +35,7 @@ class FluxSecurity(AutotoolsPackage):
     depends_on("pkgconfig")
     depends_on("libsodium@1.0.14:")
     depends_on("jansson")
-    depends_on("libuuid")
+    depends_on("uuid")
     depends_on("munge")
     depends_on("libpam")
 


### PR DESCRIPTION
libuuid is deprecated as of 11 hours ago in spack, and we need to use the uuid package instead.