### PR TITLE
flux-core: add 0.67.0

### DIFF
--- a/.github/workflows/test-build.yaml
+++ b/.github/workflows/test-build.yaml
@@ -28,3 +28,9 @@ jobs:
         with:
           package: ${{ matrix.package[0] }}
           fortran: "${{ matrix.package[1] == true }}"
+      - name: Save Stage on Failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: spack-stage-${{ matrix.package[0] }}
+          path: /tmp/runner/spack-stage

--- a/packages/flux-core/package.py
+++ b/packages/flux-core/package.py
@@ -98,6 +98,7 @@ class FluxCore(AutotoolsPackage):
     depends_on("py-pyyaml@3.10:", type=("build", "run"))
     depends_on("py-jsonschema@2.3:", type=("build", "run"), when="@:0.58.0")
     depends_on("py-ply", type=("build", "run"), when="@0.46.1:")
+    depends_on("py-setuptools", type="build", when="@0.67.0:")
     depends_on("jansson@2.10:")
     depends_on("pkgconfig")
     depends_on("lz4")

--- a/packages/flux-core/package.py
+++ b/packages/flux-core/package.py
@@ -21,6 +21,7 @@ class FluxCore(AutotoolsPackage):
     license("LGPL-3.0-only")
 
     version("master", branch="master")
+    version("0.67.0", sha256="9406e776cbeff971881143fd1b94c42ec912e5b226401d2d3d91d766dd81de8c")
     version("0.66.0", sha256="0a25cfb1ebc033c249614eb2350c6fb57b00cdf3c584d0759c787f595c360daa")
     version("0.65.0", sha256="a60bc7ed13b8e6d09e99176123a474aad2d9792fff6eb6fd4da2a00e1d2865ab")
     version("0.64.0", sha256="0334d6191915f1b89b70cdbf14f24200f8899da31090df5f502020533b304bb3")


### PR DESCRIPTION
Testing build for flux 0.67.0. If this triggers master and it works, we can probably safely merge. The build is enabled, but this version isn't added yet. This PR:

- adds version 0.67.0 of flux-core
- adds an extra step to the build test workflow to upload an artifact of the spack stage directory on failure (with the output error log)
- adds py-setuptools for 0.67.0 upward

It takes 2.5 hours because we no longer rely on any host dependencies. There were weird errors and the spack developers said they couldn't attribute anything to the packages (and couldn't help) because we were using them, so I removed them. It fixed the error at that time, and the cost is the longer build times.

This will close #245 