### PR TITLE
bug: cffi needs to be present for link (configure)

### DIFF
--- a/packages/flux-core/package.py
+++ b/packages/flux-core/package.py
@@ -93,7 +93,7 @@ class FluxCore(AutotoolsPackage):
     # Use of distutils in configure script dropped in v0.55
     # Detection of cffi version fixed in v0.68
     depends_on("python@:3.11", when="@:0.67", type=("build", "link", "run"))
-    depends_on("py-cffi@1.1:", type=("build", "run"))
+    depends_on("py-cffi@1.1:")
     depends_on("py-pyyaml@3.10:", type=("build", "run"))
     depends_on("py-jsonschema@2.3:", type=("build", "run"), when="@:0.58.0")
     depends_on("py-ply", type=("build", "run"), when="@0.46.1:")


### PR DESCRIPTION
I'm not sure if this is the issue, but there is a [build failure](https://github.com/flux-framework/spack/actions/runs/14004482129/job/39216414910) about cffi so this is the first thing I'm trying.